### PR TITLE
Update glossary.md

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -86,8 +86,8 @@
 - Blockstate：方块状态
 - TileEntity/Block Entity：(?)TileEntity/方块实体值
 - Tooltip：提示文本
-- Forge Energy/Forge Unit/Forge Power：能量
-	- 用作单位时，使用对应缩写，即FE/FU/FP
+- Forge Energy/Forge Unit/Forge Power（任何指代 `net.minecraftforge.energy` 的名称）：FE 能量
+	- 用作单位时，使用对应缩写，即 FE/FU/FP ；但仍然推荐使用 `FE`
 
 ## 动词相关
 

--- a/glossary.md
+++ b/glossary.md
@@ -86,6 +86,8 @@
 - Blockstate：方块状态
 - TileEntity/Block Entity：(?)TileEntity/方块实体值
 - Tooltip：提示文本
+- Forge Energy/Forge Unit/Forge Power：能量
+	- 用作单位时，使用对应缩写，即FE/FU/FP
 
 ## 动词相关
 

--- a/glossary.md
+++ b/glossary.md
@@ -86,7 +86,7 @@
 - Blockstate：方块状态
 - TileEntity/Block Entity：(?)TileEntity/方块实体值
 - Tooltip：提示文本
-- Forge Energy/Forge Unit/Forge Power（任何指代 `net.minecraftforge.energy` 的名称）：FE 能量
+- Forge Energy/Forge Unit/Forge Power（任何指代 `net.minecraftforge.energy` 的名称）：FE能量（注：没有空格）
 	- 用作单位时，使用对应缩写，即 FE/FU/FP ；但仍然推荐使用 `FE`
 
 ## 动词相关


### PR DESCRIPTION
tl;dr: Deal with `net.minecraftforge.energy`.

个人认为翻译时**绝对不能，也不应该**提到 MinecraftForge 或者 Forge ，理由如下：
 * 这是一个**带有缺省实现**的**框架**，并非**游戏机制**。本质上不应该与 MinecraftForge 挂钩。
 * 避免歧义。如果直译为 “Forge 能量”，在缺少上下文的情况下很容易会引发误解。

欢迎讨论。

Appendix:

For whom may concern, or request context:
Forge implemented a minimalistic energy *interface* [on Sept. 12<sup>th</sup>, 2016](https://github.com/MinecraftForge/MinecraftForge/commit/45097fed0c054407dedcf4cb9bab0e54b977d7e7). Various reactions, [comments](https://www.reddit.com/r/feedthebeast/comments/536dba/a_nonmodders_perspective_on_forge_power/) and [controversies](https://www.reddit.com/r/feedthebeast/comments/531trm/why_i_am_opposed_to_forge_energy/) from the community resulted into [an official statement by cpw](https://github.com/MinecraftForge/MinecraftForge/commit/853667c08467ff44c7f38c612364112035855661). Due to the complexity of the situation, there has been a lack of consent regarding the common translation (regardless whether it is in Chinese script or not) of the name of this new interface (also the new ecosystem) for months. This pull request is trying to address this problem.

Inputs are always welcome here; however, further research is strongly recommended before suggesting new proposal.